### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 fakeThunder
 ===========
 
-####fakeThunder is an unofficial Thunder(aka Xunlei) client for OS X.
+#### fakeThunder is an unofficial Thunder(aka Xunlei) client for OS X.
 
-###Features
+### Features
 
 1. Task synchronized with the server <http://lixian.xunlei.com>.
 2. Higher downloading speed than official Thunder client.
@@ -13,13 +13,13 @@ fakeThunder
 ![fakeThunder](http://martianz.cn/fakethunder/1.png)
 ![fakeThunder](http://martianz.cn/fakethunder/2.png)
 
-###Feedback
+### Feedback
 
 If you have any question, please mention me on [Google+](https://plus.google.com/+MartianZ/).
 
 Technical issues are also welcomed to be submitted on [GitHub](https://github.com/MartianZ/fakeThunder/issues/new).
 
 
-###License
+### License
 
 Code in the fakeThunder project is licensed under the [GNU General Public License](http://www.gnu.org/licenses/gpl.html).

--- a/aria2/README.md
+++ b/aria2/README.md
@@ -5,11 +5,11 @@ aria2c[改]
 
 fakeThunder 1.0版本采用aria2c 1.51.1版本，fakeThunder 2.0采用aria2c 1.18版本
 
-###目前修改的内容：
+### 目前修改的内容：
 
 1. 文件下载过程中，每次输出后添加flush，解决管道因为缓存读取不到内容的问题
 
-###编译Configure参数：
+### 编译Configure参数：
 
 ./configure --disable-bittorrent --disable-nls --without-sqlite3
 

--- a/fakeThunder/SFBCrashReporter/README.md
+++ b/fakeThunder/SFBCrashReporter/README.md
@@ -7,7 +7,7 @@ Adding `SFBCrashReporter` support to your application is easy:
 2.  Add the following code to your application's delegate:
 
 ```objective-c
-#import <SFBCrashReporter/SFBCrashReporter.h>
+# import <SFBCrashReporter/SFBCrashReporter.h>
 
 - (void) applicationDidFinishLaunching:(NSNotification *)aNotification
 {

--- a/fakeThunder/xunlei-lixian-api/README.md
+++ b/fakeThunder/xunlei-lixian-api/README.md
@@ -1,10 +1,10 @@
-#迅雷离线API  (TondarAPI)
+# 迅雷离线API  (TondarAPI)
 ***************  
 本项目旨在提供一个纯由Objective-C写成的迅雷离线API，方便在Mac OS X和iOS上开发相应项目。  
 **TondarAPI已经通过了iOS/Mac OS X兼容性测试** 
-###名称释义
+### 名称释义
 **Tondar**为波斯语（Persian），意为闪电  
-###功能概述
+### 功能概述
 * 迅雷离线账户登陆  
 * 获取任务列表（返回返回每个任务的详细信息，参见XunleiItemInfo）  
 * 任务类型识别  
@@ -18,13 +18,13 @@
 * 一键添加到迅雷快传
 * 对迅雷，旋风，Flashget多种专有连接的下载支持
 
-###TODO
+### TODO
 * 完善获取“保留时间”方法  
 * 增加对正在下载任务的进度获取  
 * 支持批量任务添加  
 
 ******************  
-###使用迅雷离线API的项目  
+### 使用迅雷离线API的项目  
 * 迅雷离线 for iOS
 * fakeThunder 2  (Developing)
 * [TurboX](https://github.com/lqik2004/TurboX)
@@ -32,24 +32,24 @@
 如果你使用了迅雷离线API，可以和我联系添加到这里
 
 ******************
-###要求
+### 要求
 **系统**：iOS 5.0及以上(支持ARC)和Mac OX 10.7 Lion及以上  
 **Xcode**：4.3及其以上      
 [**JSONKit**](https://github.com/johnezang/JSONKit/)
 ******************
-###源文件说明
-####依赖的开源库
+### 源文件说明
+#### 依赖的开源库
 迅雷离线API依赖的开源库有:[**JSONKit**](https://github.com/johnezang/JSONKit/)  
   
 [**JSONKit**](https://github.com/johnezang/JSONKit/) 处理JSON的开源库，详细情况可以查看项目主页
 
-#####开源库的使用######
+##### 开源库的使用 ######
 具体方法就不写了，Google或者到各个项目主页很容易就可以查到。  
 需要注意的是在启用了ARC环境下如果使用不开启ARC的库，可以找到Target->Build Phases->Compile Sources->找到需要关闭ARC的.m文件，然后加入**-fno-objc-arc**  
 ![图示1](http://ww4.sinaimg.cn/large/62d85d3dtw1dvybqxgbt3j.jpg )  
 关于开源库的使用，当时为了开发的方便加入了三个开源库能够让我用最快的时间开发出来，把主要精力放在写正则上，现在iOS和Mac OS X对JSON和正则的支持也很不错，所以可能会去掉这两个开源库，用起来方便一些。
 
-####API结构说明
+#### API结构说明
 迅雷离线API包含了10个文件  
 对外调用需要以下文件：
 HYXunleiLixianAPI，XunleiItemInfo 和Kuai  
@@ -57,7 +57,7 @@ HYXunleiLixianAPI 提供了获取任务列表，添加任务删除任务等功�
 XunleiItemInfo 提供了任务返回信息（包含任务名称，dcid等）  
 Kuai中对外调用为其中的KuaiItemInfo类，包含了从迅雷快传提取任务的各种信息
 *******************
-###更新日志  
+### 更新日志  
 * 2013-9-27 修改了部分Bug，增加了对BT文件的支持
 * 2012-10-8 v0.6.2 去掉了对regexKitLite的依赖
 * 2012-10-8 v0.6.1 去掉了对ASIHTTP的依赖
@@ -67,12 +67,12 @@ Kuai中对外调用为其中的KuaiItemInfo类，包含了从迅雷快传提取�
 * 2012-8-19 重写了接口  
 
 *******************
-###反馈问题
+### 反馈问题
 有任何问题可以和lqik2004#gmail.com进行联系  
 或者到我的博客[http://res0w.com](http://res0w.com)进行留言  
 也可以Follow我的Twitter:[@lqik2004](https://twitter.com/lqik2004)
 ********************
-###许可证
+### 许可证
 *在适当的时候我可能会更改许可证为MIT*  
 本项目采用[LGPL](http://www.gnu.org/copyleft/lesser.html)许可  
 ![LGPL](http://www.gnu.org/graphics/lgplv3-147x51.png)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
